### PR TITLE
[CLS-1911]  Few translations do not appear

### DIFF
--- a/Extractor/ExtjsClassesExtractor.php
+++ b/Extractor/ExtjsClassesExtractor.php
@@ -88,7 +88,7 @@ class ExtjsClassesExtractor implements ExtractorInterface
 
         $tokens = array();
         foreach ($tokenLines as $line) {
-            $exp = explode(':', $line);
+            $exp = explode(':', $line, 2);  // split by  first ":" only with limit=2
 
             $token = trim($exp[0]);
             $value = trim($exp[1]); // getting rid of white spaces

--- a/Tests/Unit/Extractor/ExtjsClassesExtractorTest.php
+++ b/Tests/Unit/Extractor/ExtjsClassesExtractorTest.php
@@ -27,9 +27,10 @@ class ExtjsClassesExtractorTest extends \PHPUnit_Framework_TestCase
 
         $tokens = $catalogue->all('extjs');
         $this->assertTrue(is_array($tokens));
-        $this->assertEquals(2, count($tokens));
+        $this->assertEquals(3, count($tokens));
         $this->assetToken('Company.foo.bar.MyClass.firstname', '**Firstname', $tokens);
         $this->assetToken('Company.foo.bar.MyClass.lastname', '**Lastname', $tokens);
+        $this->assetToken('Company.foo.bar.MyClass.options', '**Options:', $tokens);
     }
 
     public function test__construct()

--- a/Tests/Unit/Extractor/resources/class1.js
+++ b/Tests/Unit/Extractor/resources/class1.js
@@ -4,6 +4,7 @@
 Ext.define('Company.foo.bar.MyClass', {
     // l10n
     firstnameText: 'Firstname',
-    lastnameText: 'Lastname'
+    lastnameText: 'Lastname',
+    optionsText: 'Options:'
 
 });


### PR DESCRIPTION
split by  first ":" only with limit=2 in explode()